### PR TITLE
FIX MySQL Error creating database table

### DIFF
--- a/src/main/java/org/milkteamc/autotreechop/PlayerConfig.java
+++ b/src/main/java/org/milkteamc/autotreechop/PlayerConfig.java
@@ -58,11 +58,11 @@ public class PlayerConfig {
     private void createTable() {
         try (PreparedStatement statement = connection.prepareStatement(
                 "CREATE TABLE IF NOT EXISTS player_data (" +
-                        "uuid TEXT PRIMARY KEY," +
+                        "uuid VARCHAR(36) PRIMARY KEY," +
                         "autoTreeChopEnabled BOOLEAN," +
                         "dailyUses INT," +
                         "dailyBlocksBroken INT," +
-                        "lastUseDate TEXT);")) {
+                        "lastUseDate VARCHAR(10));")) {
             statement.executeUpdate();
         } catch (SQLException e) {
             getLogger().warning("Error creating database table: " + e.getMessage());


### PR DESCRIPTION
So i encountered this error when configuring AutoTreeChop with my MySQL database

`Error creating database table: BLOB/TEXT column 'uuid' used in key specification without a key length`

- **MySQL Version**: 8.0
- **Java Version**: eclipse-temurin:21-jre
- **Minecraft Server Version:** Paper 1.21 build 120

It seems like the **database connection** has been **established**, but there is an error when executing `createTable`.

![image](https://github.com/user-attachments/assets/4244f8c2-7491-43cf-91e6-2ca510262f18)

I found that The error happens because `MySQL` can index only the first N chars of a `TEXT` column, so the solution to the problem is to change the `TEXT` column into `VARCHAR` as primary key.

![image](https://github.com/user-attachments/assets/041dab20-0232-4828-b88f-a33865bc48a6)

After i changed the query and restart my server, the command seems working perfectly with no issue.