### PR TITLE
Refactor tree chopping logic and remove CoreProtect dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ run/
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 /.idea/
+
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'org.milkteamc'
-version = '1.5.5'
+version = '1.6.0'
 
 repositories {
     mavenCentral()
@@ -50,7 +50,6 @@ dependencies {
     implementation "com.github.Paulem79:Spigot-UpdateChecker:3cfb265fb8"
     compileOnly 'me.clip:placeholderapi:2.11.5'
     implementation "de.cubbossa:TinyTranslations-bukkit:4.5.0"
-    compileOnly "net.coreprotect:coreprotect:22.2"
     compileOnly files("./libs/Residence5.1.4.3.jar")
     compileOnly "com.github.angeschossen:LandsAPI:6.44.0"
     compileOnly 'com.sk89q.worldguard:worldguard-bukkit:7.0.9'

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ tasks.jar {
 }
 
 tasks.runServer {
-    minecraftVersion("1.21")
+    minecraftVersion("1.21.4")
 }
 
 runPaper.folia.registerTask()

--- a/src/main/java/org/milkteamc/autotreechop/AutoTreeChop.java
+++ b/src/main/java/org/milkteamc/autotreechop/AutoTreeChop.java
@@ -494,6 +494,9 @@ public class AutoTreeChop extends JavaPlugin implements Listener, CommandExecuto
                 getLogger().warning("Residence is not installed");
                 residenceEnabled = false;
             }
+        } else {
+            getLogger().warning("Residence is not installed");
+            residenceEnabled = false;
         }
 
         // GriefPrevention hook initialization
@@ -506,6 +509,9 @@ public class AutoTreeChop extends JavaPlugin implements Listener, CommandExecuto
                 getLogger().warning("GriefPrevention is not installed");
                 griefPreventionEnabled = false;
             }
+        } else {
+            getLogger().warning("GriefPrevention is not installed");
+            griefPreventionEnabled = false;
         }
 
         // Lands hook initialization
@@ -518,6 +524,9 @@ public class AutoTreeChop extends JavaPlugin implements Listener, CommandExecuto
                 getLogger().warning("Lands is not installed");
                 landsEnabled = false;
             }
+        } else {
+            getLogger().warning("Lands is not installed");
+            landsEnabled = false;
         }
         // Initialize WorldGuard support
         if (Bukkit.getPluginManager().getPlugin("WorldGuard") != null) {
@@ -528,7 +537,10 @@ public class AutoTreeChop extends JavaPlugin implements Listener, CommandExecuto
                 getLogger().warning("WorldGuard is not installed");
                 worldGuardEnabled = false;
             }
-                }
+        } else {
+            getLogger().warning("WorldGuard is not installed");
+            worldGuardEnabled = false;
+        }
     }
 
     private void loadLocale() {

--- a/src/main/java/org/milkteamc/autotreechop/AutoTreeChop.java
+++ b/src/main/java/org/milkteamc/autotreechop/AutoTreeChop.java
@@ -491,11 +491,11 @@ public class AutoTreeChop extends JavaPlugin implements Listener, CommandExecuto
                 residenceEnabled = true;
                 getLogger().info("Residence support enabled");
             } catch (Exception e) {
-                getLogger().warning("Residence is not installed");
+                getLogger().info("Residence is not installed");
                 residenceEnabled = false;
             }
         } else {
-            getLogger().warning("Residence is not installed");
+            getLogger().info("Residence is not installed");
             residenceEnabled = false;
         }
 
@@ -506,11 +506,11 @@ public class AutoTreeChop extends JavaPlugin implements Listener, CommandExecuto
                 griefPreventionEnabled = true;
                 getLogger().info("GriefPrevention support enabled");
             } catch (Exception e) {
-                getLogger().warning("GriefPrevention is not installed");
+                getLogger().info("GriefPrevention is not installed");
                 griefPreventionEnabled = false;
             }
         } else {
-            getLogger().warning("GriefPrevention is not installed");
+            getLogger().info("GriefPrevention is not installed");
             griefPreventionEnabled = false;
         }
 
@@ -521,11 +521,11 @@ public class AutoTreeChop extends JavaPlugin implements Listener, CommandExecuto
                 landsEnabled = true;
                 getLogger().info("Lands support enabled");
             } catch (Exception e) {
-                getLogger().warning("Lands is not installed");
+                getLogger().info("Lands is not installed");
                 landsEnabled = false;
             }
         } else {
-            getLogger().warning("Lands is not installed");
+            getLogger().info("Lands is not installed");
             landsEnabled = false;
         }
         // Initialize WorldGuard support
@@ -534,11 +534,11 @@ public class AutoTreeChop extends JavaPlugin implements Listener, CommandExecuto
                 worldGuardHook = new WorldGuardHook();
                 getLogger().info("WorldGuard support enabled");
             } catch (NoClassDefFoundError  e) {
-                getLogger().warning("WorldGuard is not installed");
+                getLogger().info("WorldGuard is not installed");
                 worldGuardEnabled = false;
             }
         } else {
-            getLogger().warning("WorldGuard is not installed");
+            getLogger().info("WorldGuard is not installed");
             worldGuardEnabled = false;
         }
     }

--- a/src/main/java/org/milkteamc/autotreechop/hooks/GriefPreventionHook.java
+++ b/src/main/java/org/milkteamc/autotreechop/hooks/GriefPreventionHook.java
@@ -1,0 +1,31 @@
+package org.milkteamc.autotreechop.hooks;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class GriefPreventionHook {
+    private final String flagName;
+
+    public GriefPreventionHook(String flagName) {
+        this.flagName = flagName;
+    }
+
+    public boolean checkBuild(Player player, Location location) {
+        Claim claim = GriefPrevention.instance.dataStore.getClaimAt(location, false, null);
+        
+        if (claim == null) {
+            return true;
+        }
+
+        if (claim.getOwnerID().equals(player.getUniqueId()) || 
+            player.hasPermission("autotreechop.op") || 
+            player.isOp()) {
+            return true;
+        }
+
+        return claim.hasExplicitPermission(player, ClaimPermission.valueOf(flagName));
+    }
+} 

--- a/src/main/java/org/milkteamc/autotreechop/hooks/LandsHook.java
+++ b/src/main/java/org/milkteamc/autotreechop/hooks/LandsHook.java
@@ -1,0 +1,32 @@
+package org.milkteamc.autotreechop.hooks;
+
+import me.angeschossen.lands.api.LandsIntegration;
+import me.angeschossen.lands.api.land.LandWorld;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+public class LandsHook {
+    private final LandsIntegration landsApi;
+
+    public LandsHook(Plugin plugin) {
+        this.landsApi = LandsIntegration.of(plugin);
+    }
+
+    public boolean checkBuild(Player player, Location location) {
+        if (location.getWorld() == null) {
+            return false;
+        }
+
+        LandWorld world = landsApi.getWorld(location.getWorld());
+        if (world == null) {
+            return true; // Lands is not enabled in this world
+        }
+
+        if (player.hasPermission("autotreechop.op") || player.isOp()) {
+            return true;
+        }
+
+        return world.hasFlag(player, location, null, me.angeschossen.lands.api.flags.Flags.BLOCK_BREAK, false);
+    }
+} 

--- a/src/main/java/org/milkteamc/autotreechop/hooks/ResidenceHook.java
+++ b/src/main/java/org/milkteamc/autotreechop/hooks/ResidenceHook.java
@@ -1,0 +1,31 @@
+package org.milkteamc.autotreechop.hooks;
+
+import com.bekvon.bukkit.residence.api.ResidenceApi;
+import com.bekvon.bukkit.residence.containers.Flags;
+import com.bekvon.bukkit.residence.protection.ClaimedResidence;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class ResidenceHook {
+    private final String flagName;
+
+    public ResidenceHook(String flagName) {
+        this.flagName = flagName;
+    }
+
+    public boolean checkBuild(Player player, Location location) {
+        ClaimedResidence residence = ResidenceApi.getResidenceManager().getByLoc(location);
+        
+        if (residence == null) {
+            return true;
+        }
+
+        if (residence.getOwnerUUID().equals(player.getUniqueId()) || 
+            player.isOp() || 
+            player.hasPermission("autotreechop.op")) {
+            return true;
+        }
+
+        return residence.getPermissions().playerHas(player, Flags.valueOf(flagName.toLowerCase()), true);
+    }
+} 

--- a/src/main/java/org/milkteamc/autotreechop/hooks/WorldGuardHook.java
+++ b/src/main/java/org/milkteamc/autotreechop/hooks/WorldGuardHook.java
@@ -1,0 +1,30 @@
+package org.milkteamc.autotreechop.hooks;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class WorldGuardHook {
+    public boolean checkBuild(Player player, Location location) {
+        if (player.hasPermission("autotreechop.op") || player.isOp()) {
+            return true;
+        }
+
+        com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(location);
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        RegionQuery query = container.createQuery();
+        ApplicableRegionSet set = query.getApplicableRegions(loc);
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        return !(set.queryState(localPlayer, Flags.BUILD) == StateFlag.State.DENY) &&
+               !(set.queryState(localPlayer, Flags.BLOCK_BREAK) == StateFlag.State.DENY);
+    }
+} 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: org.milkteamc.autotreechop.AutoTreeChop
 api-version: 1.17
 author: Maoyue
 description: A auto tree chopping plugin for milkteamc
-softdepend: [ PlaceholderAPI, CoreProtect, Residence, Lands ]
+softdepend: [ PlaceholderAPI, Residence, Lands, WorldGuard ]
 folia-supported: true
 
 commands:


### PR DESCRIPTION
- Simplified tree chopping process with improved concurrency handling
- Added processing location tracking to prevent recursive block breaking
- Removed CoreProtect logging integration
- Updated plugin.yml to remove CoreProtect soft dependency
- Bumped version to 1.6.0
- Improved event handling and block processing

Core Protect is not needed anymore as each block calls block break event (without calling its own)
