### PR TITLE
feat: Added increment-block-statistics

### DIFF
--- a/src/main/java/org/milkteamc/autotreechop/Config.java
+++ b/src/main/java/org/milkteamc/autotreechop/Config.java
@@ -105,6 +105,7 @@ public class Config {
     private int maxTreeSize;
     private int maxDiscoveryBlocks;
     private boolean callBlockBreakEvent;
+    private boolean incrementBlockStatistics;
 
     public Config(AutoTreeChop plugin) {
         this.plugin = plugin;
@@ -228,6 +229,7 @@ public class Config {
         maxTreeSize = config.getInt("max-tree-size", 500);
         maxDiscoveryBlocks = config.getInt("max-discovery-blocks", 1000);
         callBlockBreakEvent = config.getBoolean("call-block-break-event", true);
+        incrementBlockStatistics = config.getBoolean("increment-block-statistics", false);
 
         autoReplantEnabled = config.getBoolean("enable-auto-replant", true);
         replantDelayTicks = config.getLong("replant-delay-ticks", 15L);
@@ -544,6 +546,10 @@ public class Config {
 
     public boolean isCallBlockBreakEvent() {
         return callBlockBreakEvent;
+    }
+
+    public boolean isIncrementBlockStatistics() {
+        return incrementBlockStatistics;
     }
 
     public int getIdleTimeoutSeconds() {

--- a/src/main/java/org/milkteamc/autotreechop/utils/TreeChopUtils.java
+++ b/src/main/java/org/milkteamc/autotreechop/utils/TreeChopUtils.java
@@ -33,6 +33,8 @@ import org.milkteamc.autotreechop.AutoTreeChop;
 import org.milkteamc.autotreechop.Config;
 import org.milkteamc.autotreechop.PlayerConfig;
 
+import static org.bukkit.Statistic.MINE_BLOCK;
+
 public class TreeChopUtils {
 
     private static final Random random = new Random();
@@ -303,6 +305,7 @@ public class TreeChopUtils {
 
         BlockSnapshot finalLeafSnapshot = leafSnapshot;
 
+        Map<Material, Integer> logStatCounts = new HashMap<>();
         batchProcessor.processBatch(
                 blockList,
                 0,
@@ -342,7 +345,7 @@ public class TreeChopUtils {
                     block.breakNaturally();
 
                     if (config.isIncrementBlockStatistics()) {
-                        player.incrementStatistic(org.bukkit.Statistic.MINE_BLOCK, originalLogType);
+                        logStatCounts.merge(originalLogType, 1, Integer::sum);
                     }
 
                     actuallyRemovedLogs.add(location);
@@ -351,6 +354,11 @@ public class TreeChopUtils {
                 },
                 () -> {
                     // After all logs are removed
+                    if (config.isIncrementBlockStatistics()) {
+                        logStatCounts.forEach((mat, count) ->
+                                player.incrementStatistic(MINE_BLOCK, mat, count));
+                    }
+
                     if (config.isToolDamage()) {
                         applyToolDamage(tool, player, totalBlocks, config);
                     }
@@ -498,6 +506,7 @@ public class TreeChopUtils {
 
         List<Location> leafList = new ArrayList<>(leavesToRemove);
         int batchSize = config.getLeafRemovalBatchSize();
+        Map<Material, Integer> leafStatCounts = new HashMap<>();
 
         batchProcessor.processBatchWithTermination(
                 leafList,
@@ -515,11 +524,17 @@ public class TreeChopUtils {
                     Block leafBlock = location.getBlock();
 
                     // Remove the leaf block with all checks
-                    removeLeafBlock(leafBlock, player, config, playerConfig, hooks);
+                    removeLeafBlock(leafBlock, player, config, playerConfig, hooks, leafStatCounts);
 
                     return true; // Continue processing
                 },
                 () -> {
+                    // Flush accumulated leaf statistics
+                    if (config.isIncrementBlockStatistics()) {
+                        leafStatCounts.forEach((mat, count) ->
+                                player.incrementStatistic(MINE_BLOCK, mat, count));
+                    }
+
                     // Leaf removal complete - end session
                     sessionManager.endLeafRemovalSession(sessionId, playerKey);
                 });
@@ -534,7 +549,8 @@ public class TreeChopUtils {
             Player player,
             Config config,
             PlayerConfig playerConfig,
-            ProtectionCheckUtils.ProtectionHooks hooks) {
+            ProtectionCheckUtils.ProtectionHooks hooks,
+            Map<Material, Integer> leafStatCounts) {
 
         Location leafLocation = leafBlock.getLocation();
 
@@ -570,7 +586,6 @@ public class TreeChopUtils {
                 EffectUtils.showLeafRemovalEffect(player, leafBlock);
             }
 
-            Material leafMaterial = leafBlock.getType();
             if (config.getLeafRemovalDropItems()) {
                 leafBlock.breakNaturally();
             } else {
@@ -583,7 +598,8 @@ public class TreeChopUtils {
             }
 
             if (config.isIncrementBlockStatistics()) {
-                player.incrementStatistic(org.bukkit.Statistic.MINE_BLOCK, leafMaterial);
+                Material leafMaterial = leafBlock.getType();
+                leafStatCounts.merge(leafMaterial, 1, Integer::sum);
             }
 
             // Update daily blocks count if needed

--- a/src/main/java/org/milkteamc/autotreechop/utils/TreeChopUtils.java
+++ b/src/main/java/org/milkteamc/autotreechop/utils/TreeChopUtils.java
@@ -341,6 +341,10 @@ public class TreeChopUtils {
                     }
                     block.breakNaturally();
 
+                    if (config.isIncrementBlockStatistics()) {
+                        player.incrementStatistic(org.bukkit.Statistic.MINE_BLOCK, originalLogType);
+                    }
+
                     actuallyRemovedLogs.add(location);
                     sessionManager.trackRemovedLogForPlayer(playerUUID.toString(), location);
                     playerConfig.incrementDailyBlocksBroken();
@@ -566,6 +570,7 @@ public class TreeChopUtils {
                 EffectUtils.showLeafRemovalEffect(player, leafBlock);
             }
 
+            Material leafMaterial = leafBlock.getType();
             if (config.getLeafRemovalDropItems()) {
                 leafBlock.breakNaturally();
             } else {
@@ -575,6 +580,10 @@ public class TreeChopUtils {
                 } else {
                     leafBlock.setType(Material.AIR, false);
                 }
+            }
+
+            if (config.isIncrementBlockStatistics()) {
+                player.incrementStatistic(org.bukkit.Statistic.MINE_BLOCK, leafMaterial);
             }
 
             // Update daily blocks count if needed

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -83,6 +83,9 @@ max-discovery-blocks: 1000
 # Call BlockBreakEvent for each block
 # true = Better plugin compatibility
 call-block-break-event: true
+# Increment player's Minecraft block-break statistic (Statistic.MINE_BLOCK) for every block broken by ATC,
+# including all chain-chopped logs and leaves (if leaf removal is enabled).
+increment-block-statistics: false
 
 # Protection plugins setting
 # If you are using Residence, you can set which Flag players have access to AutoTreeChop in residence.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -83,7 +83,7 @@ max-discovery-blocks: 1000
 # Call BlockBreakEvent for each block
 # true = Better plugin compatibility
 call-block-break-event: true
-# Increment player's Minecraft block-break statistic (Statistic.MINE_BLOCK) for every block broken by ATC,
+# Increment player's Minecraft block-break statistic (Statistic.MINE_BLOCK) for every block broken by AutoTreeChop,
 # including all chain-chopped logs and leaves (if leaf removal is enabled).
 increment-block-statistics: false
 


### PR DESCRIPTION
Add a new boolean config option `increment-block-statistics` (default: false) that calls `player.incrementStatistic(MINE_BLOCK)` for every block broken by ATC, including all chain-chopped logs and leaves removed by leaf removal. Disabled by default to preserve existing behavior. 